### PR TITLE
play2:install goal: applied new TypeSafe download URL pattern

### DIFF
--- a/src/main/java/de.akquinet.innovation.play.maven/Play2InstallPlayMojo.java
+++ b/src/main/java/de.akquinet.innovation.play.maven/Play2InstallPlayMojo.java
@@ -95,7 +95,14 @@ public class Play2InstallPlayMojo
 
         try {
 
-            URL zipUrl = new URL( "http://download.playframework.org/releases/play-" + play2version + ".zip" );
+            // New download URL pattern starting from 2.1.0, the 2.1-RC* versions use the old URL pattern.
+            // See https://groups.google.com/forum/#!topic/play-framework/SKOXG1YRKa8
+            URL zipUrl;
+            if( play2version.startWith( "2.0" ) || play2version.startWith( "2.1-RC" ) ) {
+                zipUrl = new URL( "http://downloads.typesafe.com/releases/play-" + play2version + ".zip" );
+            } else {
+                zipUrl = new URL( "http://downloads.typesafe.com/play/" + play2version  + "/play-" + play2version + ".zip" );
+            }
             FileUtils.forceMkdir( play2basedirFile );
 
             // Download


### PR DESCRIPTION
This should fix issue #33.

Typesafe changed the download URLs pattern starting from 2.1.0.
The 2.1-RC\* versions use the old URL pattern.

See https://groups.google.com/forum/#!topic/play-framework/SKOXG1YRKa8
